### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/skillrampup/65e060e7-ceaa-447d-b7b6-a96edade435e/e430a55d-21d2-4a8d-bf7b-90c8b686c90d/_apis/work/boardbadge/ab99bd51-f7d8-47af-904f-54b03a632997)](https://dev.azure.com/skillrampup/65e060e7-ceaa-447d-b7b6-a96edade435e/_boards/board/t/e430a55d-21d2-4a8d-bf7b-90c8b686c90d/Microsoft.RequirementCategory)

--- a/demo-webapp/demo-webapp/Startup.cs
+++ b/demo-webapp/demo-webapp/Startup.cs
@@ -50,3 +50,5 @@ namespace demo_webapp
         }
     }
 }
+
+//Added some comments


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/skillrampup/65e060e7-ceaa-447d-b7b6-a96edade435e/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.